### PR TITLE
Fix InvoiceItem model name

### DIFF
--- a/app.js
+++ b/app.js
@@ -59,7 +59,7 @@ Invoice = sequelize.define('invoices', {
   }
 });
 
-InvoiceItems = sequelize.define('invoice_items', {
+InvoiceItem = sequelize.define('invoice_items', {
   id: {
     type: Sequelize.INTEGER,
     primaryKey: true,


### PR DESCRIPTION
The initial defined name of model is `InvoiceItems` and then in queries you use `InvoiceItem`.